### PR TITLE
Disable StyleCop If .NET 3.5 Not Installed

### DIFF
--- a/src/CSharp/MetadataWebApi/MetadataWebApi.targets
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.targets
@@ -10,8 +10,8 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <SignAssembly>true</SignAssembly>
     <SourceAnalysisOverrideSettingsFile>$(SolutionDir)\StyleCop.settings</SourceAnalysisOverrideSettingsFile>
-  <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' == ''">false</StyleCopEnabled>
-  <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' != ''">true</StyleCopEnabled>
+    <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' == ''">false</StyleCopEnabled>
+    <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' != ''">true</StyleCopEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <CodeAnalysisTreatWarningsAsErrors Condition="'$(CodeAnalysisTreatWarningsAsErrors)' == ''">true</CodeAnalysisTreatWarningsAsErrors>

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.targets
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.targets
@@ -10,8 +10,8 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <SignAssembly>true</SignAssembly>
     <SourceAnalysisOverrideSettingsFile>$(SolutionDir)\StyleCop.settings</SourceAnalysisOverrideSettingsFile>
-	<StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' == ''">false</StyleCopEnabled>
-	<StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' != ''">true</StyleCopEnabled>
+  <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' == ''">false</StyleCopEnabled>
+  <StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' != ''">true</StyleCopEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <CodeAnalysisTreatWarningsAsErrors Condition="'$(CodeAnalysisTreatWarningsAsErrors)' == ''">true</CodeAnalysisTreatWarningsAsErrors>

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.targets
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.targets
@@ -10,6 +10,8 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <SignAssembly>true</SignAssembly>
     <SourceAnalysisOverrideSettingsFile>$(SolutionDir)\StyleCop.settings</SourceAnalysisOverrideSettingsFile>
+	<StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' == ''">false</StyleCopEnabled>
+	<StyleCopEnabled Condition="'$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5@Version)' != ''">true</StyleCopEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <CodeAnalysisTreatWarningsAsErrors Condition="'$(CodeAnalysisTreatWarningsAsErrors)' == ''">true</CodeAnalysisTreatWarningsAsErrors>


### PR DESCRIPTION
This pull request disables StyleCop analysis if .NET 3.5 is not installed on the local machine. This allows the C# sample code to build cleanly on a machine with just Windows 10 and Visual Studio 2015 installed.