### PR TITLE
Apply +x to NuGet.exe on Linux

### DIFF
--- a/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
@@ -28,6 +28,7 @@
       <RequireRestoreConsent>false</RequireRestoreConsent>
     </PropertyGroup>
     <Message Text="Restoring NuGet packages..." Importance="normal" />
+    <Exec Condition="'$(OS)' == 'Unix'" Command="chmod +x %22$(NuGetExePath)%22" />
     <Exec Command="%22$(NuGetExePath)%22 restore %22$(SolutionFile)%22" LogStandardErrorAsError="true" />
   </Target>
   <Target Name="Test" Condition="'$(OS)' != 'Unix'">


### PR DESCRIPTION
Apply the ```+x``` flag to ```NuGet.exe``` using ```chmod``` on Linux at build time so that we don't need to ensure it is set every time NuGet is updated to a new version.