### PR TITLE
Disable hanging integration tests.

### DIFF
--- a/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/RequiresServiceCredentialsFactAttribute.cs
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/RequiresServiceCredentialsFactAttribute.cs
@@ -20,8 +20,12 @@ namespace Experian.Qas.Updates.Metadata.WebApi.V1
         public RequiresServiceCredentialsFactAttribute()
             : base()
         {
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("QAS_ElectronicUpdates_UserName")) ||
-                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("QAS_ElectronicUpdates_Password")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            {
+                this.Skip = "Temporarily disabled as AppVeyor CI test run hangs.";
+            }
+            else if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("QAS_ElectronicUpdates_UserName")) ||
+                     string.IsNullOrEmpty(Environment.GetEnvironmentVariable("QAS_ElectronicUpdates_Password")))
             {
                 this.Skip = "No service credentials are configured.";
             }


### PR DESCRIPTION
The AppVeyor CI's integration tests are hanging for some reason. Need to investigate why and fix. Until then, this PR disables those tests to fix the CI.