### PR TITLE
Fix #11 by removing parallelism for file download.

### DIFF
--- a/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/IntegrationTests.cs
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/IntegrationTests.cs
@@ -130,7 +130,7 @@ namespace Experian.Qas.Updates.Metadata.WebApi.V1
             }
         }
 
-        [RequiresServiceCredentialsFact(Skip = "Test hangs at non-deterministic points in AppVeyor CI - reason unknown.")]
+        [RequiresServiceCredentialsFact]
         public async Task Program_MainAsync_Downloads_Data_Files()
         {
             // Arrange

--- a/src/CSharp/MetadataWebApi/MetadataWebApi/Program.cs
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi/Program.cs
@@ -102,8 +102,6 @@ namespace Experian.Qas.Updates.Metadata.WebApi.V1
 
                     try
                     {
-                        List<Task> downloadTasks = new List<Task>();
-
                         Stopwatch stopwatch = Stopwatch.StartNew();
 
                         // Create a file store in which to cache information about which files

--- a/src/CSharp/MetadataWebApi/MetadataWebApi/Program.cs
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi/Program.cs
@@ -130,12 +130,19 @@ namespace Experian.Qas.Updates.Metadata.WebApi.V1
                                         {
                                             // We already have this file, download not required
                                             Console.WriteLine("File with hash '{0}' already downloaded.", file.MD5Hash);
-                                            continue;
                                         }
-
-                                        // Queue each file to download asynchronously
-                                        Task task = DownloadFileAsync(service, fileStore, group, file, downloadRootPath, verifyDownloads, tokenSource.Token);
-                                        downloadTasks.Add(task);
+                                        else
+                                        {
+                                            // Download the file
+                                            await DownloadFileAsync(
+                                                service,
+                                                fileStore,
+                                                group,
+                                                file,
+                                                downloadRootPath,
+                                                verifyDownloads,
+                                                tokenSource.Token);
+                                        }
                                     }
 
                                     Console.WriteLine();
@@ -143,9 +150,6 @@ namespace Experian.Qas.Updates.Metadata.WebApi.V1
 
                                 Console.WriteLine();
                             }
-
-                            // Wait for all of the tasks to download files to complete
-                            Task.WaitAll(downloadTasks.ToArray(), tokenSource.Token);
                         }
 
                         stopwatch.Stop();


### PR DESCRIPTION
It appears the hang was caused by some sort of race condition and/or resource starvation on the relatively low specification of the VMs used for AppVeyor CI builds when multiple tasks were queued to download the available data files in parallel. This means that the issue may also have been apparent on Travis (if it weren't for #13). 

As the tasks are not CPU intensive and are I/O-bound the download parallelism has been removed to make the application sequential which has resolved the hang to fix #11 at the expense of increasing the overall test run time on more powerful machines.