### PR TITLE
Add VB.NET environment variable support and README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ TestResults
 *.sln.ide
 *.suo
 *.user
+*.userprefs

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ BuildOutput
 NuGet.exe.old
 obj
 packages
+QASData
 StyleCop.Cache
 TestResults
 *~

--- a/src/VB.NET/MetadataWebApi/MetadataWebApi.sln
+++ b/src/VB.NET/MetadataWebApi/MetadataWebApi.sln
@@ -7,8 +7,6 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "MetadataWebApi", "MetadataW
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{76514EA6-0412-4E0B-A583-3F2FA29C8C4F}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\.gitattributes = ..\..\.gitattributes
-		..\..\.gitignore = ..\..\.gitignore
 		Build.cmd = Build.cmd
 		Experian.ico = Experian.ico
 		FxCopDictionary.xml = FxCopDictionary.xml
@@ -18,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		MetadataWebApi.ruleset = MetadataWebApi.ruleset
 		MetadataWebApi.snk = MetadataWebApi.snk
 		MetadataWebApi.targets = MetadataWebApi.targets
-		..\..\..\README.md = ..\..\..\README.md
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{4CE36FD6-8EB7-493B-9F96-5600E68DB138}"

--- a/src/VB.NET/MetadataWebApi/MetadataWebApi/Program.vb
+++ b/src/VB.NET/MetadataWebApi/MetadataWebApi/Program.vb
@@ -4,16 +4,13 @@
 '  </copyright>
 ' -----------------------------------------------------------------------
 
-Imports System
 Imports System.Configuration
-Imports System.Diagnostics
 Imports System.Globalization
 Imports System.IO
 Imports System.Net
 Imports System.Reflection
 Imports System.Security.Cryptography
 Imports System.Text
-Imports Experian.Qas.Updates.Metadata.WebApi.V1
 
 ''' <summary>
 ''' A class representing an example implementation of the QAS Electronic Updates
@@ -30,8 +27,8 @@ Friend Class Program
 
         Try
             ' Get the configuration settings to connect to the QAS Electronic Updates Metadata API
-            Dim userName As String = ConfigurationManager.AppSettings.Item("QAS:ElectronicUpdates:UserName")
-            Dim password As String = ConfigurationManager.AppSettings.Item("QAS:ElectronicUpdates:Password")
+            Dim userName As String = GetAppSetting("UserName")
+            Dim password As String = GetAppSetting("Password")
 
             Dim downloadRootPath As String = "QASData"
             Dim verifyDownloads As Boolean = True
@@ -62,7 +59,7 @@ Friend Class Program
             ' Enumerate the package groups and list their packages and files
             If (Not response.PackageGroups Is Nothing AndAlso response.PackageGroups.Count > 0) Then
 
-                Dim stopwatch As Stopwatch = stopwatch.StartNew()
+                Dim stopwatch As Stopwatch = Stopwatch.StartNew()
 
                 ' Create a file store in which to cache information about which files
                 ' have already been downloaded from the Metadata API service.
@@ -168,6 +165,33 @@ Friend Class Program
         Console.ReadKey()
 
     End Sub
+
+    ''' <summary>
+    ''' Gets the configuration setting with the specified name.
+    ''' </summary>
+    ''' <param name="name">The name of the setting to get the value of.</param>
+    ''' <returns>
+    ''' The value of the setting specified by <paramref name="name"/>, if found; otherwise <see langword="null"/>.
+    ''' </returns>
+    Private Shared Function GetAppSetting(ByVal name As String) As String
+
+        '' Build the full name of the setting
+        Dim settingName As String = String.Format(CultureInfo.InvariantCulture, "QAS:ElectronicUpdates:{0}", name)
+
+        '' Is the setting configured in the application configuration file?
+        Dim value As String = ConfigurationManager.AppSettings.Item(settingName)
+
+        '' If Not, try the environment variables
+        If (String.IsNullOrEmpty(value)) Then
+
+            settingName = String.Format(CultureInfo.InvariantCulture, "QAS_ElectronicUpdates_{0}", name)
+            value = Environment.GetEnvironmentVariable(settingName)
+
+        End If
+
+        Return value
+
+    End Function
 
     ''' <summary>
     ''' Validates that the specified file was downloaded correctly.

--- a/src/VB.NET/MetadataWebApi/README.md
+++ b/src/VB.NET/MetadataWebApi/README.md
@@ -1,0 +1,70 @@
+# QAS Electronic Updates Metadata REST API VB.NET Sample Integration Code
+
+## Overview
+
+This directory contains a VB.NET application that can be used to determine what data files are available to download for an account, generate download URLs for the files and then download them onto the local file system.
+
+Further documentation of the application is provided by the comments in the source code itself.
+
+*This documentation describes the application as found in this [Git repository](https://github.com/experiandataquality/electronicupdates). It may no longer apply if you modify the sample code.*
+
+## Prerequisites
+
+### Compilation and Debugging
+
+The following prerequisites are required to compile and debug the application:
+
+ * Microsoft Windows 7 SP1 (or later);
+ * One of the following editions of [Microsoft Visual Studio](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx):
+   * Visual Studio Community 2013 with Update 4 (or later);
+   * Visual Studio Premium 2013 with Update 4 (or later);
+   * Visual Studio Ultimate 2013 with Update 4 (or later);
+   * Visual Studio 2015 RC (or later).
+
+### Runtime
+
+The following prerequisites are required to run the compiled application:
+
+ * Microsoft Windows 7 SP1 (or later);
+ * Microsoft .NET Framework 4.5 (or later).
+
+## Compliation
+
+To compile the application, you can do any of the following:
+
+ * Open ```MetadataWebApi.sln``` in Visual Studio;
+ * Run ```Build.cmd``` from the command prompt.
+
+## Setup
+
+To set up the application for usage you could either:
+
+ 1. Set your credentials in the ```QAS_ElectronicUpdates_UserName``` and ```QAS_ElectronicUpdates_Password``` environment variables just before running the application (**recommended**);
+ 1. Configure the credentials in the ```MetadataWebApi.exe.config``` configuration file. If you place your credentials in this file ensure that you have adequate security controls in place to protect your account credentials as they are sensitive.
+
+Other approaches are possible but are considered outside the scope of this documentation.
+
+## Usage
+
+To run the application, execute the following command from the directory containing the compiled executable:
+
+```batchfile
+MetadataWebApi.exe
+```
+
+## Example Usage
+
+Below is an example set of commands that could be run on Windows to download all the latest data files from QAS Electronic Updates onto the local machine into a ```QASData``` directory in the same directory as the application
+
+```batchfile
+set QAS_ElectronicUpdates_UserName=MyUserName
+set QAS_ElectronicUpdates_Password=MyPassword
+MetadataWebApi.exe
+```
+
+## Compatibility
+
+This application has been compiled and tested on the following platforms:
+
+ * Visual Studio 2013 Premium with Update 4 on Windows 8.1 (Build 9600);
+ * Visual Studio 2015 RC on Windows 10 (Build 10074).


### PR DESCRIPTION
Adds environment variable support to the VB.NET sample code to match the C# and Python samples and a README.md.

Also updates ```.gitignore``` to exclude the ```QASData``` folder used by all the sample code as the downloaded data directory for when debugging locally and to ignore ```*.userprefs``` for when using MonoDevelop.