### PR TITLE
Update Ruby For OS X Support

### DIFF
--- a/src/Ruby/MetadataWebApi/Gemfile
+++ b/src/Ruby/MetadataWebApi/Gemfile
@@ -1,0 +1,6 @@
+# Copyright (c) Experian. All rights reserved.
+
+source 'https://rubygems.org'
+
+gem "rest-client", "~> 1.8"
+gem "minitest", "~> 5.6"

--- a/src/Ruby/MetadataWebApi/README.md
+++ b/src/Ruby/MetadataWebApi/README.md
@@ -28,6 +28,7 @@ Other approaches are possible but are considered outside the scope of this docum
 To build and test the gem, execute the following command from the directory containing the Ruby code:
 
 ```sh
+bundle
 rake
 ```
 
@@ -37,12 +38,21 @@ Below is an example Ruby script that could be used on a Linux machine to downloa
 
 First set the credentials to use:
 
+### Linux/OS X
+
 ```sh
+export QAS_ElectronicUpdates_UserName=MyUserName
+export QAS_ElectronicUpdates_Password=MyPassword
+```
+
+### Windows
+
+```batchfile
 set QAS_ElectronicUpdates_UserName=MyUserName
 set QAS_ElectronicUpdates_Password=MyPassword
 ```
 
-Then run a ruby script similar to this:
+Then you can run a ruby script similar to this:
 
 ```ruby
 #!/usr/bin/env ruby
@@ -84,4 +94,5 @@ end
 This script was tested with the following Ruby versions and platforms:
 
  * Ruby 1.9.3p484 on Ubuntu 14.04.2 LTS;
- * Python 2.2.2p95 on Windows 8.1 (Build 9600).
+ * Ruby 2.1.0p0 on OS X Yosemite (10.10.2);
+ * Ruby 2.2.2p95 on Windows 8.1 (Build 9600).


### PR DESCRIPTION
This PR updates the sample for Ruby to:

  1. Add a Gemfile;
  1. Update ```README.md``` with OS X (and Linux) instructions/compatibility note and fix a typo.