### PR TITLE
Build .NET Samples With Visual Studio 2015

### DIFF
--- a/src/CSharp/MetadataWebApi/Build.cmd
+++ b/src/CSharp/MetadataWebApi/Build.cmd
@@ -1,9 +1,9 @@
 @echo off
 
-set _MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_MSBuild% set _MSBuild="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+set _MSBuild="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %_MSBuild% set _MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_MSBuild% echo Error: Could not find MSBuild.exe. && exit /b 1
 
 %_MSBuild% "%~dp0\MetadataWebApi.msbuild" /v:minimal /maxcpucount /nodeReuse:false %*

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.sln
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetadataWebApi", "MetadataWebApi\MetadataWebApi.csproj", "{B3A7B441-933E-49CF-B567-EF9D6C8333E5}"
 EndProject

--- a/src/CSharp/MetadataWebApi/README.md
+++ b/src/CSharp/MetadataWebApi/README.md
@@ -31,7 +31,7 @@ The following prerequisites are required to compile and debug the application:
    * Visual Studio Community 2013 with Update 4 (or later);
    * Visual Studio Premium 2013 with Update 4 (or later);
    * Visual Studio Ultimate 2013 with Update 4 (or later);
-   * Visual Studio 2015 RC (or later).
+   * Visual Studio 2015 (or later).
 
 ### Runtime
 
@@ -102,4 +102,5 @@ This application has been compiled and tested on the following platforms:
  * MonoDevelop 5.9.0 on Ubuntu 14.04.2 LTS;
  * Mono 4.0.1 on OS X Yosemite (10.10.2);
  * Visual Studio 2013 Premium with Update 4 on Windows 8.1 (Build 9600);
- * Visual Studio 2015 RC on Windows 10 (Build 10074).
+ * Visual Studio 2013 Premium with Update 5 on Windows 8.1 (Build 9600);
+ * Visual Studio 2015 Enterprise on Windows 10 (Build 9600).

--- a/src/VB.NET/MetadataWebApi/Build.cmd
+++ b/src/VB.NET/MetadataWebApi/Build.cmd
@@ -1,9 +1,9 @@
 @echo off
 
-set _MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_MSBuild% set _MSBuild="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+set _MSBuild="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %_MSBuild% set _MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_MSBuild% set _MSBuild="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_MSBuild% echo Error: Could not find MSBuild.exe. && exit /b 1
 
 %_MSBuild% "%~dp0\MetadataWebApi.msbuild" /v:minimal /maxcpucount /nodeReuse:false %*

--- a/src/VB.NET/MetadataWebApi/MetadataWebApi.sln
+++ b/src/VB.NET/MetadataWebApi/MetadataWebApi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "MetadataWebApi", "MetadataWebApi\MetadataWebApi.vbproj", "{81340D5E-B260-4F26-B641-D13F9DBBB877}"
 EndProject

--- a/src/VB.NET/MetadataWebApi/README.md
+++ b/src/VB.NET/MetadataWebApi/README.md
@@ -19,7 +19,7 @@ The following prerequisites are required to compile and debug the application:
    * Visual Studio Community 2013 with Update 4 (or later);
    * Visual Studio Premium 2013 with Update 4 (or later);
    * Visual Studio Ultimate 2013 with Update 4 (or later);
-   * Visual Studio 2015 RC (or later).
+   * Visual Studio 2015 (or later).
 
 ### Runtime
 
@@ -67,4 +67,5 @@ MetadataWebApi.exe
 This application has been compiled and tested on the following platforms:
 
  * Visual Studio 2013 Premium with Update 4 on Windows 8.1 (Build 9600);
- * Visual Studio 2015 RC on Windows 10 (Build 10074).
+ * Visual Studio 2013 Premium with Update 5 on Windows 8.1 (Build 9600);
+ * Visual Studio 2015 Enterprise on Windows 8.1 (Build 9600).


### PR DESCRIPTION
This PR updates the C# and VB.NET samples to prefer building with Visual Studio 2015.