### PR TITLE
Build C# on Linux and OS X with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ solution: ./src/CSharp/MetadataWebApi/MetadataWebApi.sln
 script:
   - ./src/CSharp/MetadataWebApi/build.sh
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - secure: "NB87Ouxaay9VqWPv+G1Bm71EsJWAY8kv+dPNDFYHHQQ93dPbCzoekF6p2RYdJ8hN++UsEk1ppeCtT7ERRsfNpZp1me5yeOgS+hmst+wbvpKiJUFERzVirlbNAZZarWxL/4Wlq4Pz97ynrF73wxkJgs0rR/Wf9IyUBdMoeOGeaCgZmS004RPO9kr0jF6+zZ+r0Rj1r+PwXWbRV2+zT1F53shvFEwawQnvTVi10qN1f27TnGk6lo2RySxDB1uj7zhvQbpD6+iIHfrGAjhK6bxOjRn3Im1Os6tLzxjom8xLTTeEAdTrpm9fz7KnERmK5mwwtmTnJklrj1BEGKujen/epQ75/s6k9kxvnJYuni4h9IZxL7A2jg8s7vgQZ4C+ugb6Q74ig4efwfDsgMiwCfhVRJitO7u4ifzX05S1Ph6P3IuByTpY6cKGNeruXIHZEehgtOVZwCiJn+zxgNhqs1LbNmXxJMxEp6+TkR5GW2h5ErdU59Vl14gwxy8V2QHk1h7ryk5lxaklQG5UqwoTY3ZZzbxBWAeb/AJqCC+0uhOfuZCcMp1unglXvpxl/rBWyKmeCaZ7no4kM8TBzib+pLA08LjYRYAr+gZDhCQpyxVc5TNHHlRU68eS0TbOif4WrKvYvr/FSTpppnSRTHIUs9sb6YierWamKLyeEfiTRdXhsx0="


### PR DESCRIPTION
This PR updates the Travis CI to build the C# sample code on Linux *and* OS X after changes were made to Travis CI to support this (see travis-ci/travis-ci/issues/3546).