### PR TITLE
Enable tests on Linux and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: csharp
+
+mono:
+  - latest
+  - beta
+  - alpha
+  - nightly
+
 solution: ./src/CSharp/MetadataWebApi/MetadataWebApi.sln
 script:
   - ./src/CSharp/MetadataWebApi/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: csharp
 
 mono:
   - latest
-  - beta
-  - alpha
-  - nightly
 
 solution: ./src/CSharp/MetadataWebApi/MetadataWebApi.sln
 script:

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/MetadataWebApi.Tests.csproj
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/MetadataWebApi.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -89,7 +89,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/packages.config
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.Tests/packages.config
@@ -6,5 +6,5 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
@@ -38,7 +38,7 @@
     <Exec Condition="'$(OS)' == 'Unix'" Command="chmod +x %22$(NuGetExePath)%22" />
     <Exec Command="$(DotNetExecPrefix)%22$(NuGetExePath)%22 restore %22$(SolutionFile)%22" LogStandardErrorAsError="true" />
   </Target>
-  <Target Name="Test" Condition="'$(OS)' != 'Unix'">
+  <Target Name="Test">
     <ItemGroup Condition="'$(TestTool)' == ''">
       <TestTool Include="$(SolutionDir)packages\xunit.runner.console.*\tools\xunit.console.exe" />
     </ItemGroup>

--- a/src/CSharp/MetadataWebApi/README.md
+++ b/src/CSharp/MetadataWebApi/README.md
@@ -22,7 +22,7 @@ The following prerequisites are required to compile and debug the application:
 
 #### Linux
 
- * [Mono](http://www.mono-project.com/download/) 4.0.1 (or later);
+ * [Mono](http://www.mono-project.com/download/) 4.0.2 (or later);
  * [Mono Develop](http://www.monodevelop.com/download/) 5.9.0 (or later).
 
 #### Windows
@@ -38,7 +38,7 @@ The following prerequisites are required to run the compiled application:
 
 ### Linux/OS X
 
- * [Mono](http://www.mono-project.com/download/) 4.0.1 (or later).
+ * [Mono](http://www.mono-project.com/download/) 4.0.2 (or later).
 
 ### Windows
 

--- a/src/CSharp/MetadataWebApi/README.md
+++ b/src/CSharp/MetadataWebApi/README.md
@@ -22,7 +22,7 @@ The following prerequisites are required to compile and debug the application:
 
 #### Linux
 
- * [Mono](http://www.mono-project.com/download/) 4.0.2 (or later);
+ * [Mono](http://www.mono-project.com/download/) 4.2.1 (or later);
  * [Mono Develop](http://www.monodevelop.com/download/) 5.9.0 (or later).
 
 #### Windows
@@ -38,7 +38,7 @@ The following prerequisites are required to run the compiled application:
 
 ### Linux/OS X
 
- * [Mono](http://www.mono-project.com/download/) 4.0.2 (or later).
+ * [Mono](http://www.mono-project.com/download/) 4.2.1 (or later).
 
 ### Windows
 
@@ -64,7 +64,7 @@ To compile the application, you can do any of the following:
 To set up the application for usage you could either:
 
  1. Set your credentials in the ```QAS_ElectronicUpdates_UserName``` and ```QAS_ElectronicUpdates_Password``` environment variables just before running the application (**recommended**);
- 1. Configure the credentials in the ```MetadataWebApi.exe.config``` configuration file. If you place your credentials in this file ensure that you have adequate security controls in place to protect your account credentials as they are sensitive. 
+ 1. Configure the credentials in the ```MetadataWebApi.exe.config``` configuration file. If you place your credentials in this file ensure that you have adequate security controls in place to protect your account credentials as they are sensitive.
 
 Other approaches are possible but are considered outside the scope of this documentation.
 


### PR DESCRIPTION
Now that Mono 4.0.2 is released, xUnit tests should now run on Mono for Linux and OS X.

This resolves #13.