### PR TITLE
Measure code coverage with codecov.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # QAS Electronic Updates
 
+<!--
 [![Issues](https://img.shields.io/github/issues/experiandataquality/electronicupdates.svg?label=Issues)](https://github.com/experiandataquality/electronicupdates/issues) [![License](https://img.shields.io/github/license/experiandataquality/electronicupdates.svg?label=License)](https://github.com/experiandataquality/electronicupdates/blob/master/LICENSE)
+-->
 
 | | Linux/OS X | Windows |
 |:-:|:-:|:-:|
-| **C# Build Status** | [![Build status](https://img.shields.io/travis/experiandataquality/electronicupdates/master.svg)](https://travis-ci.org/experiandataquality/electronicupdates) | [![Build status](https://img.shields.io/appveyor/ci/experiandataquality/electronicupdates/master.svg)](https://ci.appveyor.com/project/experiandataquality/electronicupdates) |
+| **C# Build Status** | [![Build status](https://img.shields.io/travis/experiandataquality/electronicupdates/master.svg)](https://travis-ci.org/experiandataquality/electronicupdates) | [![Build status](https://img.shields.io/appveyor/ci/experiandataquality/electronicupdates/master.svg)](https://ci.appveyor.com/project/experiandataquality/electronicupdates) [![Coverage Status](https://img.shields.io/codecov/c/github/experiandataquality/electronicupdates/master.svg)](https://codecov.io/github/experiandataquality/electronicupdates) |
 | **C# Build History** | [![Build history](https://ci-buildstats.azurewebsites.net/travisci/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/experiandataquality/electronicupdates) |  [![Build history](https://ci-buildstats.azurewebsites.net/appveyor/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/experiandataquality/electronicupdates) |
 
 ## Overview

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ build:
   project: src\CSharp\MetadataWebApi\MetadataWebApi.msbuild
   verbosity: minimal
 
-after_build: 
+after_build:
     - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
     - pip install codecov
-    - codecov -f "src\BuildOutput\MetadataWebApi_coverage.xml"
+    - codecov -f "src\CSharp\MetadataWebApi\BuildOutput\MetadataWebApi_coverage.xml"
 
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,11 @@ build:
   project: src\CSharp\MetadataWebApi\MetadataWebApi.msbuild
   verbosity: minimal
 
+after_build: 
+    - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+    - pip install codecov
+    - codecov -f "src\BuildOutput\MetadataWebApi_coverage.xml"
+
 nuget:
   disable_publish_on_pr: true
 

--- a/src/CSharp/MetadataWebApi/.nuget/packages.config
+++ b/src/CSharp/MetadataWebApi/.nuget/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="OpenCover" version="4.6.166" />
   <package id="xunit.runner.console" version="2.0.0" />
 </packages>

--- a/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
+++ b/src/CSharp/MetadataWebApi/MetadataWebApi.msbuild
@@ -9,6 +9,7 @@
     <RunTests Condition="'$(RunTests)' == '' and '$(TF_BUILD)' != 'True' ">true</RunTests>
     <BuildProperties Condition=" '$(TF_BUILD)' != 'True' ">Platform=$(Platform);OutputPath=$(OutputPath)</BuildProperties>
     <DotNetExecPrefix Condition="'$(OS)' == 'Unix'">mono </DotNetExecPrefix>
+    <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' and '$(OS)' != 'Unix'">true</EnableCodeCoverage>
     <CodeTaskFactoryAssembly Condition="'$(MSBuildToolsVersion)' != '14.0'">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll</CodeTaskFactoryAssembly>
     <CodeTaskFactoryAssembly Condition="'$(MSBuildToolsVersion)' == '14.0'">$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</CodeTaskFactoryAssembly>
   </PropertyGroup>
@@ -48,9 +49,17 @@
     <ItemGroup>
       <TestContainer Include="$(OutputPath)\MetadataWebApi.*Test*.dll" />
     </ItemGroup>
+    <PropertyGroup>
+      <_TestCommand>@(TestContainer->'%22%(fullpath)%22', ' ')</_TestCommand>
+      <_CodeCoverageXml>$(OutputPath)\MetadataWebApi_coverage.xml</_CodeCoverageXml>
+      <_OpenCoverVersion>4.6.166</_OpenCoverVersion>
+      <_OpenCoverTool>%22$(SolutionDir)packages\OpenCover.$(_OpenCoverVersion)\Tools\OpenCover.Console.exe%22</_OpenCoverTool>
+      <_OpenCoverOptions>-register:user -hideskipped:All -mergebyhash -skipautoprops -filter:%22+[*]* -[xunit*]* -[*Tests]*%22 -returntargetcode -output:%22$(_CodeCoverageXml)%22</_OpenCoverOptions>
+    </PropertyGroup>
     <Message Text="Running tests..." Importance="high" />
     <Exec Condition="'$(OS)' == 'Unix'" Command="chmod +x %22$(TestTool)%22" />
-    <Exec Command="$(DotNetExecPrefix)%22$(TestTool)%22 @(TestContainer->'%22%(fullpath)%22', ' ')" WorkingDirectory="$(OutputPath)" />
+    <Exec Condition="'$(EnableCodeCoverage)' != 'true'" Command="$(DotNetExecPrefix)%22$(TestTool)%22 $(_TestCommand)" WorkingDirectory="$(OutputPath)" />
+    <Exec Condition="'$(EnableCodeCoverage)' == 'true'" Command="$(_OpenCoverTool) $(_OpenCoverOptions) -target:$(TestTool) -targetargs:$(_TestCommand)" WorkingDirectory="$(OutputPath)" />
     <Message Text="Tests complete." Importance="high" />
   </Target>
   <Target Name="UpdateAssemblyConfiguration">

--- a/src/CSharp/MetadataWebApi/README.md
+++ b/src/CSharp/MetadataWebApi/README.md
@@ -2,17 +2,10 @@
 
 ## Build Status
 
-### Linux/OS X
-
-[![Build status](https://img.shields.io/travis/experiandataquality/electronicupdates/master.svg)](https://travis-ci.org/experiandataquality/electronicupdates)
-
-[![Build history](https://ci-buildstats.azurewebsites.net/travisci/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/experiandataquality/electronicupdates)
-
-### Windows
-
-[![Build status](https://img.shields.io/appveyor/ci/experiandataquality/electronicupdates/master.svg)](https://ci.appveyor.com/project/experiandataquality/electronicupdates)
-
-[![Build history](https://ci-buildstats.azurewebsites.net/appveyor/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/experiandataquality/electronicupdates)
+| | Linux/OS X | Windows |
+|:-:|:-:|:-:|
+| **Build Status** | [![Build status](https://img.shields.io/travis/experiandataquality/electronicupdates/master.svg)](https://travis-ci.org/experiandataquality/electronicupdates) | [![Build status](https://img.shields.io/appveyor/ci/experiandataquality/electronicupdates/master.svg)](https://ci.appveyor.com/project/experiandataquality/electronicupdates) [![Coverage Status](https://img.shields.io/codecov/c/github/experiandataquality/electronicupdates/master.svg)](https://codecov.io/github/experiandataquality/electronicupdates) |
+| **Build History** | [![Build history](https://ci-buildstats.azurewebsites.net/travisci/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/experiandataquality/electronicupdates) |  [![Build history](https://ci-buildstats.azurewebsites.net/appveyor/chart/experiandataquality/electronicupdates?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/experiandataquality/electronicupdates) |
 
 ## Overview
 


### PR DESCRIPTION
This PR sets up the C# sample code build (on Windows) to collect code coverage using OpenCov, and then submit the result to codecov.io when built in AppVeyor.